### PR TITLE
Set application's type to prelogin

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -7,4 +7,7 @@
     <licence>AGPLv3</licence>
     <author>Patrick Paysant / CNRS DSI</author>
     <require>7</require>
+    <types>
+    	<prelogin/>
+    </types>
 </info>


### PR DESCRIPTION
Application must loaded at preLogin phase to listen user_servervars2
createAuser events
