### PR TITLE
Valorisation du champ email en BDD lors de la création d'un compte local

### DIFF
--- a/hooks/userhooks.php
+++ b/hooks/userhooks.php
@@ -16,6 +16,16 @@ class UserHooks {
 
     public function postCreateUser(\OC\User\User $user) {
         $this->mailAction->mailUserCreation($user);
+
+        // if user's uid (username) is a email, additional treatments :
+        if(filter_var($user->getUID(), FILTER_VALIDATE_EMAIL)) {
+
+            // add the email on oc_preferences
+            \OC_Preferences::setValue($user->getUID(), 'settings', 'email', $user->getUID());
+
+            // add the IsLocal on oc_preferences to know the user's account's type
+            \OC_Preferences::setValue($user->getUID(), 'settings', 'IsLocal', TRUE);
+        }
     }
 
     public function preDeleteUser(\OC\User\User $user) {


### PR DESCRIPTION
Mantis 40758 : Valoriser le champ email en BDD lors de la création d'un compte local.